### PR TITLE
[codex] Add limited-range MIP tutorial

### DIFF
--- a/docs/source/imaging/imaging.rst
+++ b/docs/source/imaging/imaging.rst
@@ -158,6 +158,76 @@ The same process can then be done to obtain the XZ plane view of our sample by r
 
     **Figure 10:** The XZ projection of our bead images after reslicing.
 
+Limited-Range Maximum-Intensity Projections
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Dense volumetric data can be difficult to interpret when a maximum-intensity projection is calculated across the
+entire z-stack. Bright structures above or below the cell of interest can obscure the object being inspected. In these
+cases, a limited-range maximum-intensity projection can be more useful: inspect the stack, choose the z-slices that
+contain the cell or subcellular structure of interest, and calculate the projection only across that range. This is
+especially useful for checking whether puncta or particles are inside a cell rather than above or below it.
+
+This workflow is most useful after any required deskewing, shearing correction, or top-view rotation has already been
+applied. First inspect the dataset in Fiji/ImageJ and identify the z-slice range of interest. If the projection should
+only include a single cell or region, draw an ROI in Fiji/ImageJ and record the ROI coordinates as
+``x, y, width, height``. The scripts below use one-based inclusive z-slice numbers, matching the slice labels displayed
+in Fiji/ImageJ. The ROI coordinates use the ImageJ/Fiji convention where ``x`` and ``y`` are the upper-left pixel
+coordinates.
+
+**Python**
+
+Download the standalone Python script:
+:download:`limited_range_mip.py <../../../downloads/common/python/limited_range_mip.py>`.
+The script includes `PEP 723 <https://peps.python.org/pep-0723/>`_ metadata, so ``uv`` can create the temporary
+environment and install the required dependencies automatically.
+
+For example, to process all channel TIFF stacks for a cell, crop to an ROI, and project only slices 451 through 640:
+
+.. code-block:: bash
+
+    uv run downloads/common/python/limited_range_mip.py \
+        "/path/to/Top_shear45_mlv2_Cell10/1_CH0*.tif" \
+        --first-z 451 \
+        --last-z 640 \
+        --roi 372 405 232 175 \
+        --xy-pixel-size 0.15 \
+        --z-step-size 0.15 \
+        --output-dir "/path/to/MIPs_cell10_roi3"
+
+The script writes XY, XZ, YZ, and combined ``three`` projection TIFF files for each input stack. If the data have
+already been resampled so the z pixel size matches the lateral pixel size, either omit ``--xy-pixel-size`` and
+``--z-step-size`` or provide the same value for both. Add ``--write-cropped-stack`` if the cropped limited-z volume
+should also be saved. Large cropped stacks are written as BigTIFF automatically.
+
+**MATLAB**
+
+Download the MATLAB helper files:
+:download:`limited_range_mip.m <../../../downloads/common/matlab/limited_range_mip.m>`,
+:download:`readtiffstack.m <../../../downloads/common/matlab/readtiffstack.m>`, and
+:download:`writetiffstack.m <../../../downloads/common/matlab/writetiffstack.m>`. The ``readtiffstack.m`` and
+``writetiffstack.m`` helpers support standard TIFF and BigTIFF files, and ``limited_range_mip.m`` creates the same XY,
+XZ, YZ, and combined projection outputs.
+
+.. code-block:: matlab
+
+    addpath('/path/to/altair/downloads/common/matlab');
+
+    inputPath = '/path/to/Top_shear45_mlv2_Cell10/1_CH00_000000.tif';
+    outputDir = '/path/to/MIPs_cell10_roi3';
+
+    zRange = [451, 640];          % one-based, inclusive
+    roi = [372, 405, 232, 175];   % x, y, width, height from Fiji/ImageJ
+    xyPixelSize = 0.15;
+    zStepSize = 0.15;
+
+    limited_range_mip(inputPath, outputDir, zRange, roi, xyPixelSize, zStepSize);
+
+Leave ``roi`` empty to project the full field of view:
+
+.. code-block:: matlab
+
+    limited_range_mip(inputPath, outputDir, zRange, [], xyPixelSize, zStepSize);
+
 Deconvolution
 ^^^^^^^^^^^^^
 

--- a/downloads/common/matlab/limited_range_mip.m
+++ b/downloads/common/matlab/limited_range_mip.m
@@ -1,0 +1,120 @@
+function [] = limited_range_mip(inputPath, outputDir, zRange, roi, xyPixelSize, zStepSize, writeCroppedStack)
+%LIMITED_RANGE_MIP Create XY, XZ, YZ, and combined limited-z MIPs.
+%
+% inputPath: path to a 3D TIFF stack in Y, X, Z order after MATLAB loading.
+% outputDir: directory where output TIFF files will be written.
+% zRange: [firstZ, lastZ], one-based inclusive. Use [] for the full stack.
+% roi: optional ImageJ/Fiji ROI [x, y, width, height]. Use [] for no crop.
+% xyPixelSize: lateral pixel size.
+% zStepSize: z-step size, in the same units as xyPixelSize.
+% writeCroppedStack: optional true/false to write the cropped limited-z stack.
+
+    if nargin < 7
+        writeCroppedStack = false;
+    end
+
+    if ~exist(outputDir, 'dir')
+        mkdir(outputDir);
+    end
+
+    [image, ~, ~, numberImages] = readtiffstack(inputPath);
+
+    if ~isempty(zRange)
+        if numel(zRange) ~= 2
+            error('zRange must be [firstZ, lastZ] or [].');
+        end
+        if zRange(1) < 1 || zRange(2) < zRange(1) || zRange(2) > numberImages
+            error('zRange must be one-based, inclusive, and within the stack.');
+        end
+        image = image(:, :, zRange(1):zRange(2));
+    end
+
+    if ~isempty(roi)
+        if numel(roi) ~= 4
+            error('roi must be [x, y, width, height] or [].');
+        end
+        x1 = roi(1) + 1;
+        y1 = roi(2) + 1;
+        x2 = x1 + roi(3) - 1;
+        y2 = y1 + roi(4) - 1;
+        if x1 < 1 || y1 < 1 || x2 > size(image, 2) || y2 > size(image, 1)
+            error('ROI exceeds the image dimensions.');
+        end
+        image = image(y1:y2, x1:x2, :);
+    end
+
+    if xyPixelSize <= 0 || zStepSize <= 0
+        error('xyPixelSize and zStepSize must be positive.');
+    end
+    zScale = zStepSize / xyPixelSize;
+
+    mipXY = max(image, [], 3);
+    mipXZ = scaleRows(squeeze(max(image, [], 1))', zScale, class(image));
+    mipYZ = scaleRows(squeeze(max(image, [], 2))', zScale, class(image))';
+
+    [~, stem, ~] = fileparts(inputPath);
+    if isempty(zRange)
+        suffix = 'full_stack';
+    else
+        suffix = sprintf('z%04d-%04d', zRange(1), zRange(2));
+    end
+
+    imwrite(mipXY, fullfile(outputDir, sprintf('%s_%s_mip_xy.tif', stem, suffix)));
+    imwrite(mipXZ, fullfile(outputDir, sprintf('%s_%s_mip_xz.tif', stem, suffix)));
+    imwrite(mipYZ, fullfile(outputDir, sprintf('%s_%s_mip_yz.tif', stem, suffix)));
+
+    montage = zeros(size(mipXY, 1) + size(mipXZ, 1), size(mipXY, 2) + size(mipYZ, 2), class(image));
+    montage(1:size(mipXY, 1), 1:size(mipXY, 2)) = mipXY;
+    montage(size(mipXY, 1) + 1:end, 1:size(mipXZ, 2)) = mipXZ;
+    montage(1:size(mipYZ, 1), size(mipXY, 2) + 1:end) = mipYZ;
+    imwrite(montage, fullfile(outputDir, sprintf('%s_%s_mip_three.tif', stem, suffix)));
+
+    if writeCroppedStack
+        writetiffstack(image, fullfile(outputDir, sprintf('%s_%s_stack.tif', stem, suffix)));
+    end
+end
+
+function scaled = scaleRows(image, scaleFactor, outputClass)
+    if abs(scaleFactor - 1) < eps
+        scaled = cast(image, outputClass);
+        return;
+    end
+
+    oldRows = size(image, 1);
+    newRows = max(1, round(oldRows * scaleFactor));
+    [oldX, oldY] = meshgrid(1:size(image, 2), 1:oldRows);
+    [newX, newY] = meshgrid(1:size(image, 2), linspace(1, oldRows, newRows));
+    scaled = interp2(oldX, oldY, double(image), newX, newY, 'linear', 0);
+    scaled = castToClass(scaled, outputClass);
+end
+
+function output = castToClass(image, outputClass)
+    if startsWith(outputClass, 'uint') || startsWith(outputClass, 'int')
+        limits = integerLimits(outputClass);
+        image = min(max(round(image), limits(1)), limits(2));
+    end
+    output = cast(image, outputClass);
+end
+
+function limits = integerLimits(outputClass)
+    switch outputClass
+        case 'uint8'
+            limits = [intmin('uint8'), intmax('uint8')];
+        case 'uint16'
+            limits = [intmin('uint16'), intmax('uint16')];
+        case 'uint32'
+            limits = [intmin('uint32'), intmax('uint32')];
+        case 'uint64'
+            limits = [intmin('uint64'), intmax('uint64')];
+        case 'int8'
+            limits = [intmin('int8'), intmax('int8')];
+        case 'int16'
+            limits = [intmin('int16'), intmax('int16')];
+        case 'int32'
+            limits = [intmin('int32'), intmax('int32')];
+        case 'int64'
+            limits = [intmin('int64'), intmax('int64')];
+        otherwise
+            limits = [-Inf, Inf];
+    end
+end

--- a/downloads/common/matlab/readtiffstack.m
+++ b/downloads/common/matlab/readtiffstack.m
@@ -1,0 +1,60 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%
+%           Function created by Bo-Jui Chang (bjo4), 2021/12/6 @ Dallas
+%           Modified to support BigTIFF and dynamic data types
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+function [FinalImage, mImage, nImage, NumberImages] = readtiffstack(path)
+
+    InfoImage = imfinfo(path);
+    mImage = InfoImage(1).Height;
+    nImage = InfoImage(1).Width;
+    NumberImages = length(InfoImage);
+
+    bitsPerSample = InfoImage(1).BitsPerSample;
+
+    if isfield(InfoImage(1), 'SampleFormat')
+        sampleFormat = InfoImage(1).SampleFormat;
+    else
+        sampleFormat = 1;
+    end
+
+    if sampleFormat == 3
+        if bitsPerSample == 32
+            dataType = 'single';
+        else
+            dataType = 'double';
+        end
+    elseif sampleFormat == 2
+        if bitsPerSample == 8
+            dataType = 'int8';
+        elseif bitsPerSample == 16
+            dataType = 'int16';
+        elseif bitsPerSample == 32
+            dataType = 'int32';
+        else
+            dataType = 'int64';
+        end
+    else
+        if bitsPerSample == 8
+            dataType = 'uint8';
+        elseif bitsPerSample == 16
+            dataType = 'uint16';
+        elseif bitsPerSample == 32
+            dataType = 'uint32';
+        else
+            dataType = 'uint64';
+        end
+    end
+
+    FinalImage = zeros(mImage, nImage, NumberImages, dataType);
+
+    warnState = warning('off', 'all');
+    TifLink = Tiff(path, 'r');
+    for i = 1:NumberImages
+        TifLink.setDirectory(i);
+        FinalImage(:, :, i) = TifLink.read();
+    end
+    TifLink.close();
+    warning(warnState);
+end

--- a/downloads/common/matlab/writetiffstack.m
+++ b/downloads/common/matlab/writetiffstack.m
@@ -1,0 +1,58 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%
+%           Function created by Bo-Jui Chang (bjo4), 2021/12/6 @ Dallas
+%           Modified to support BigTIFF and dynamic data types
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+function [] = writetiffstack(image, path)
+
+    [nx, ny, nz] = size(image);
+    imgType = class(image);
+
+    switch imgType
+        case {'uint8', 'int8'}
+            bitsPerSample = 8;
+        case {'uint16', 'int16'}
+            bitsPerSample = 16;
+        case {'uint32', 'int32', 'single'}
+            bitsPerSample = 32;
+        case {'uint64', 'int64', 'double'}
+            bitsPerSample = 64;
+        otherwise
+            bitsPerSample = 16;
+    end
+
+    bytesPerPixel = bitsPerSample / 8;
+    estimatedSize = nx * ny * nz * bytesPerPixel;
+
+    threshold = 4.0 * 1024^3;
+    if estimatedSize > threshold
+        tiffFile = Tiff(path, 'w8');
+    else
+        tiffFile = Tiff(path, 'w');
+    end
+
+    tagstruct.Photometric = Tiff.Photometric.MinIsBlack;
+    tagstruct.ImageLength = nx;
+    tagstruct.ImageWidth = ny;
+    tagstruct.PlanarConfiguration = Tiff.PlanarConfiguration.Chunky;
+    tagstruct.Compression = Tiff.Compression.None;
+    tagstruct.BitsPerSample = bitsPerSample;
+
+    if contains(imgType, 'int') && ~contains(imgType, 'uint')
+        tagstruct.SampleFormat = Tiff.SampleFormat.Int;
+    elseif contains(imgType, 'single') || contains(imgType, 'double')
+        tagstruct.SampleFormat = Tiff.SampleFormat.IEEEFP;
+    else
+        tagstruct.SampleFormat = Tiff.SampleFormat.UInt;
+    end
+
+    for iz = 1:nz
+        tiffFile.setTag(tagstruct);
+        tiffFile.write(image(:, :, iz));
+        if iz < nz
+            tiffFile.writeDirectory();
+        end
+    end
+    tiffFile.close();
+end

--- a/downloads/common/python/limited_range_mip.py
+++ b/downloads/common/python/limited_range_mip.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#     "numpy>=1.23",
+#     "tifffile>=2023.7.10",
+# ]
+# ///
+"""Create limited-z maximum-intensity projections from 3D TIFF stacks.
+
+The script expects TIFF stacks in Z, Y, X axis order. It writes XY, XZ, YZ,
+and combined-view projections for each input file.
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional, Sequence
+
+import numpy as np
+import tifffile
+
+BIGTIFF_THRESHOLD_BYTES = 4 * 1024**3
+
+
+@dataclass(frozen=True)
+class Roi:
+    """ImageJ/Fiji-style ROI coordinates."""
+
+    x: int
+    y: int
+    width: int
+    height: int
+
+
+@dataclass(frozen=True)
+class ZRange:
+    """One-based inclusive z range."""
+
+    first: int
+    last: int
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Create limited-z maximum-intensity projections from one or more "
+            "3D TIFF stacks. Z indices are one-based and inclusive, matching "
+            "the slice labels shown in Fiji/ImageJ."
+        )
+    )
+    parser.add_argument(
+        "inputs",
+        nargs="+",
+        help=(
+            "Input TIFF stack path(s). Quoted glob patterns such as "
+            "'/data/Cell10/1_CH0*.tif' are expanded by this script."
+        ),
+    )
+    parser.add_argument(
+        "--first-z",
+        type=int,
+        required=True,
+        help="First z slice to include, using one-based inclusive indexing.",
+    )
+    parser.add_argument(
+        "--last-z",
+        type=int,
+        required=True,
+        help="Last z slice to include, using one-based inclusive indexing.",
+    )
+    parser.add_argument(
+        "--roi",
+        type=int,
+        nargs=4,
+        metavar=("X", "Y", "WIDTH", "HEIGHT"),
+        help=(
+            "Optional ImageJ/Fiji-style XY crop in pixels. X and Y are the "
+            "upper-left corner coordinates, and WIDTH/HEIGHT are crop sizes."
+        ),
+    )
+    parser.add_argument(
+        "--xy-pixel-size",
+        type=float,
+        help=(
+            "Optional lateral pixel size. Provide with --z-step-size to scale "
+            "XZ/YZ projections so the displayed z axis has the same physical "
+            "pixel spacing as X/Y."
+        ),
+    )
+    parser.add_argument(
+        "--z-step-size",
+        type=float,
+        help="Optional z-step size in the same units as --xy-pixel-size.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        help="Directory for outputs. Defaults to a MIPs folder beside each input.",
+    )
+    parser.add_argument(
+        "--suffix",
+        help=(
+            "Optional output suffix. Defaults to z<first>-<last>, for example "
+            "z0451-0640."
+        ),
+    )
+    parser.add_argument(
+        "--write-cropped-stack",
+        action="store_true",
+        help="Also write the cropped limited-z stack for each input.",
+    )
+    parser.add_argument(
+        "--no-montage",
+        action="store_true",
+        help="Skip the combined XY/XZ/YZ projection image.",
+    )
+    return parser.parse_args()
+
+
+def expand_inputs(patterns: Sequence[str]) -> list[Path]:
+    paths: list[Path] = []
+    for pattern in patterns:
+        matches = sorted(glob.glob(pattern))
+        if matches:
+            paths.extend(Path(match) for match in matches)
+        else:
+            paths.append(Path(pattern))
+
+    missing = [path for path in paths if not path.exists()]
+    if missing:
+        missing_text = "\n".join(str(path) for path in missing)
+        raise FileNotFoundError(f"Input TIFF file(s) not found:\n{missing_text}")
+
+    return paths
+
+
+def validate_z_range(z_range: ZRange, z_len: int) -> slice:
+    if z_range.first < 1:
+        raise ValueError("--first-z must be at least 1")
+    if z_range.last < z_range.first:
+        raise ValueError("--last-z must be greater than or equal to --first-z")
+    if z_range.last > z_len:
+        raise ValueError(
+            f"Requested z range {z_range.first}-{z_range.last}, "
+            f"but stack only has {z_len} slices"
+        )
+
+    return slice(z_range.first - 1, z_range.last)
+
+
+def validate_roi(roi: Roi, y_len: int, x_len: int) -> tuple[slice, slice]:
+    if roi.x < 0 or roi.y < 0:
+        raise ValueError("ROI X and Y must be non-negative")
+    if roi.width < 1 or roi.height < 1:
+        raise ValueError("ROI WIDTH and HEIGHT must be at least 1")
+
+    x_stop = roi.x + roi.width
+    y_stop = roi.y + roi.height
+    if x_stop > x_len or y_stop > y_len:
+        raise ValueError(
+            f"ROI x={roi.x}, y={roi.y}, width={roi.width}, height={roi.height} "
+            f"exceeds image size X={x_len}, Y={y_len}"
+        )
+
+    return slice(roi.y, y_stop), slice(roi.x, x_stop)
+
+
+def cast_like(values: np.ndarray, dtype: np.dtype) -> np.ndarray:
+    if np.issubdtype(dtype, np.integer):
+        info = np.iinfo(dtype)
+        values = np.clip(np.rint(values), info.min, info.max)
+    return values.astype(dtype, copy=False)
+
+
+def rescale_z_axis(image: np.ndarray, scale: float, dtype: np.dtype) -> np.ndarray:
+    if scale <= 0:
+        raise ValueError("Projection scale must be positive")
+    if abs(scale - 1.0) < 1e-9:
+        return image
+
+    old_rows = image.shape[0]
+    new_rows = max(1, int(round(old_rows * scale)))
+    if new_rows == old_rows:
+        return image
+
+    old_positions = np.arange(old_rows, dtype=np.float64)
+    new_positions = np.linspace(0, old_rows - 1, new_rows)
+    flat_image = image.reshape(old_rows, -1).astype(np.float64, copy=False)
+    flat_scaled = np.empty((new_rows, flat_image.shape[1]), dtype=np.float64)
+
+    for column in range(flat_image.shape[1]):
+        flat_scaled[:, column] = np.interp(
+            new_positions,
+            old_positions,
+            flat_image[:, column],
+        )
+
+    scaled = flat_scaled.reshape((new_rows, *image.shape[1:]))
+    return cast_like(scaled, dtype)
+
+
+def projection_scale(
+    xy_pixel_size: Optional[float],
+    z_step_size: Optional[float],
+) -> float:
+    if xy_pixel_size is None and z_step_size is None:
+        return 1.0
+    if xy_pixel_size is None or z_step_size is None:
+        raise ValueError("Provide both --xy-pixel-size and --z-step-size, or neither")
+    if xy_pixel_size <= 0 or z_step_size <= 0:
+        raise ValueError("--xy-pixel-size and --z-step-size must be positive")
+    return z_step_size / xy_pixel_size
+
+
+def write_tiff(path: Path, image: np.ndarray) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tifffile.imwrite(
+        path,
+        image,
+        bigtiff=image.nbytes > BIGTIFF_THRESHOLD_BYTES,
+        photometric="minisblack",
+    )
+
+
+def create_montage(
+    xy: np.ndarray,
+    xz: np.ndarray,
+    yz: np.ndarray,
+    dtype: np.dtype,
+) -> np.ndarray:
+    height = xy.shape[0] + xz.shape[0]
+    width = xy.shape[1] + yz.shape[1]
+    montage = np.zeros((height, width), dtype=dtype)
+    montage[: xy.shape[0], : xy.shape[1]] = xy
+    montage[xy.shape[0] :, : xz.shape[1]] = xz
+    montage[: yz.shape[0], xy.shape[1] :] = yz
+    return montage
+
+
+def process_stack(
+    input_path: Path,
+    output_dir: Path,
+    z_range: ZRange,
+    roi: Optional[Roi],
+    scale: float,
+    suffix: str,
+    write_cropped_stack: bool,
+    write_montage: bool,
+) -> list[Path]:
+    stack = tifffile.imread(input_path)
+    if stack.ndim != 3:
+        raise ValueError(
+            f"{input_path} has shape {stack.shape}; expected a 3D TIFF stack "
+            "in Z, Y, X axis order"
+        )
+
+    z_slice = validate_z_range(z_range, stack.shape[0])
+    stack = stack[z_slice, :, :]
+
+    if roi is not None:
+        y_slice, x_slice = validate_roi(roi, stack.shape[1], stack.shape[2])
+        stack = stack[:, y_slice, x_slice]
+
+    xy = stack.max(axis=0)
+    xz = rescale_z_axis(stack.max(axis=1), scale, stack.dtype)
+    yz = rescale_z_axis(stack.max(axis=2), scale, stack.dtype).T
+
+    output_paths: list[Path] = []
+    stem = input_path.stem
+    projections = {
+        "xy": xy,
+        "xz": xz,
+        "yz": yz,
+    }
+    if write_montage:
+        projections["three"] = create_montage(xy, xz, yz, stack.dtype)
+
+    for name, image in projections.items():
+        output_path = output_dir / f"{stem}_{suffix}_mip_{name}.tif"
+        write_tiff(output_path, image)
+        output_paths.append(output_path)
+
+    if write_cropped_stack:
+        output_path = output_dir / f"{stem}_{suffix}_stack.tif"
+        write_tiff(output_path, stack)
+        output_paths.append(output_path)
+
+    return output_paths
+
+
+def main() -> None:
+    args = parse_args()
+    paths = expand_inputs(args.inputs)
+    z_range = ZRange(args.first_z, args.last_z)
+    roi = Roi(*args.roi) if args.roi is not None else None
+    scale = projection_scale(args.xy_pixel_size, args.z_step_size)
+    suffix = args.suffix or f"z{args.first_z:04d}-{args.last_z:04d}"
+
+    for input_path in paths:
+        output_dir = args.output_dir or input_path.parent / "MIPs"
+        output_paths = process_stack(
+            input_path=input_path,
+            output_dir=output_dir,
+            z_range=z_range,
+            roi=roi,
+            scale=scale,
+            suffix=suffix,
+            write_cropped_stack=args.write_cropped_stack,
+            write_montage=not args.no_montage,
+        )
+        for output_path in output_paths:
+            print(f"Saved {output_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds a basic image-processing tutorial for limited-range maximum-intensity projections in the existing Imaging Process documentation. The tutorial explains why projecting a selected z-range can make dense volumetric light-sheet data easier to interpret, especially when users need to evaluate whether puncta or particles are inside a cell rather than above or below it.

## Changes

- Added a new `Limited-Range Maximum-Intensity Projections` section under Image Stack Processing.
- Added inline Python and MATLAB call examples using Fiji/ImageJ-style z ranges and ROI coordinates.
- Added a standalone PEP 723 Python script, `downloads/common/python/limited_range_mip.py`, runnable with `uv run` and able to write XY, XZ, YZ, combined-view, and optional cropped-stack outputs.
- Added MATLAB helper files in `downloads/common/matlab/`, including BigTIFF-aware `readtiffstack.m` and `writetiffstack.m` helpers plus `limited_range_mip.m`.
- Used Sphinx `:download:` links so the generated docs include direct downloadable script artifacts.

## Validation

- `ruff check --target-version py39 downloads/common/python/limited_range_mip.py`
- `ruff format --check downloads/common/python/limited_range_mip.py`
- Synthetic TIFF projection test covering one-based z-range conversion, ROI cropping, scaled XZ/YZ projections, montage shape, and cropped-stack output.
- `env UV_PROJECT_ENVIRONMENT="$(mktemp -d)/.venv" uv run --frozen --extra docs sphinx-build -b html docs/source docs/build/html`
- Browser inspection of the rendered Imaging Process page confirmed the new sidebar entry, readable tutorial layout, contained code blocks, and internal downloadable links for the added scripts.
